### PR TITLE
Fixes a segmentation fault for unnamed declarations.

### DIFF
--- a/source/diagnostics.h
+++ b/source/diagnostics.h
@@ -84,7 +84,7 @@ namespace cpp2 {
         std::string result = {};
         auto parent = decl->get_parent();
         
-        while(parent != nullptr) {
+        while(parent != nullptr && parent->identifier != nullptr) {
             result = parent->identifier->to_string() + dot(result) + result;
             parent = parent->get_parent();
         }


### PR DESCRIPTION
An example is:
```
func: (t: int, f) = {
  f(t + 2);
}

main: () = {
  x: int = 4;

  // :(v) = ... causes the error.
  func(x, :(v) = std::cout << "Value: " << v << std::endl);
}
```